### PR TITLE
Decouple variant cleanup from hardcoded EX prefab name

### DIFF
--- a/Packages/minminmean.supine/Editor/Supine/OldSupineCleaner.cs
+++ b/Packages/minminmean.supine/Editor/Supine/OldSupineCleaner.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 
 using ExpressionsMenu = VRC.SDK3.Avatars.ScriptableObjects.VRCExpressionsMenu;
@@ -11,11 +12,16 @@ using ExpressionParameter = VRC.SDK3.Avatars.ScriptableObjects.VRCExpressionPara
 namespace Supine
 {
     /// <summary>
-    /// v3.0.2以前のごろ寝を削除するためのユーティリティクラス
+    /// v3.0.2以前のごろ寝や、SupineMASlot導入以前に設置されたMA Prefabなど、
+    /// 現行アーキテクチャと互換性のない過去のごろ寝システムの残骸を削除するためのユーティリティクラス
     /// </summary>
 
     class OldSupineCleaner
     {
+        // SupineMASlot導入以前に設置された、マーカーの無いMA Prefabの互換削除用
+        private const string LegacyNormalPrefabName = "SupineMA";
+        private const string LegacyExPrefabName     = "SupineMA_EX";
+
         private static ExpressionParameter[] _oldSupineParameters = new ExpressionParameter[11]
             {
                 new ExpressionParameter { name = "VRCLockPose",                 valueType = ExpressionParameters.ValueType.Int },
@@ -92,6 +98,32 @@ namespace Supine
         private static bool IsSupineParameter(ExpressionParameter parameter)
         {
             return _oldSupineParameters.Contains(parameter, new ExParameterComparer());
+        }
+
+        /// <summary>
+        /// SupineMASlot導入以前（マーカーの無い）に設置された通常版/EX版のMA Prefabを削除する。
+        /// マーカーが無いため通常のSortAndCleanMAPrefabでは検出できない、
+        /// バージョン跨ぎでの入れ替え時の残骸を掃除するための互換対応。
+        /// </summary>
+        /// <param name="avatarTransform">アバターのTransform</param>
+        /// <param name="excluding">削除対象から除外する（今回新しく設置した）MA Prefab</param>
+        public static void RemoveMarkerlessMAPrefabs(Transform avatarTransform, GameObject excluding)
+        {
+            List<GameObject> targets = new List<GameObject>();
+            foreach (Transform child in avatarTransform)
+            {
+                if (child.gameObject == excluding) continue;
+                bool isKnownMAPrefabName = child.name == LegacyNormalPrefabName || child.name == LegacyExPrefabName;
+                if (isKnownMAPrefabName && child.GetComponent<SupineMASlot>() == null)
+                {
+                    targets.Add(child.gameObject);
+                }
+            }
+
+            foreach (GameObject target in targets)
+            {
+                GameObject.DestroyImmediate(target);
+            }
         }
     }
 }

--- a/Packages/minminmean.supine/Editor/Supine/OldSupineCleaner.cs
+++ b/Packages/minminmean.supine/Editor/Supine/OldSupineCleaner.cs
@@ -40,39 +40,51 @@ namespace Supine
         
         public static void CleanCombinedSupine(VRCAvatarDescriptor avatarDescriptor)
         {
+            bool hasCombinedMenu = HasCombinedSupineMenu(avatarDescriptor.expressionsMenu);
+            bool hasOldParameters = HasOldSupineParameters(avatarDescriptor.expressionParameters);
+            if (!hasCombinedMenu && !hasOldParameters) return;
+
             // SerializedObjectで操作する
             SerializedObject descriptorObj = new SerializedObject(avatarDescriptor);
             descriptorObj.FindProperty("customizeAnimationLayers").boolValue = true;
             descriptorObj.FindProperty("customExpressions").boolValue = true;
 
-            // ExMenuを組む
-            SerializedProperty descriptorMenuProp = descriptorObj.FindProperty("expressionsMenu");
+            if (hasCombinedMenu)
+            {
+                // ExMenuを組む
+                SerializedProperty descriptorMenuProp = descriptorObj.FindProperty("expressionsMenu");
+                ExpressionsMenu descriptorMenu = avatarDescriptor.expressionsMenu;
 
-            ExpressionsMenu descriptorMenu = avatarDescriptor.expressionsMenu;
-            if (descriptorMenu == null) descriptorMenu = new ExpressionsMenu();
-            List<ExpressionsMenuControl> descriptorControls = descriptorMenu.controls;
-            if (descriptorControls == null) descriptorControls = new List<ExpressionsMenuControl>();
-            
-            EditorUtility.SetDirty(descriptorMenu);
-            descriptorMenu.controls = RemoveCombinedExMenuControls(descriptorControls);
+                EditorUtility.SetDirty(descriptorMenu);
+                descriptorMenu.controls = RemoveCombinedExMenuControls(descriptorMenu.controls);
 
-            descriptorMenuProp.objectReferenceValue = descriptorMenu;
+                descriptorMenuProp.objectReferenceValue = descriptorMenu;
+            }
 
-            // ExParametersを組む
-            SerializedProperty descriptorParamsProp = descriptorObj.FindProperty("expressionParameters");
+            if (hasOldParameters)
+            {
+                // ExParametersを組む
+                SerializedProperty descriptorParamsProp = descriptorObj.FindProperty("expressionParameters");
+                ExpressionParameters descriptorParams = avatarDescriptor.expressionParameters;
 
-            ExpressionParameters descriptorParams = avatarDescriptor.expressionParameters;
-            if (descriptorParams == null) descriptorParams = new ExpressionParameters();
-            ExpressionParameter[] descriptorParamsArray = descriptorParams.parameters;
-            if (descriptorParamsArray == null) descriptorParamsArray = new ExpressionParameter[0];
+                EditorUtility.SetDirty(descriptorParams);
+                descriptorParams.parameters = RemoveCombinedExParameters(descriptorParams.parameters);
 
-            EditorUtility.SetDirty(descriptorParams);
-            descriptorParams.parameters = RemoveCombinedExParameters(descriptorParamsArray);
-
-            descriptorParamsProp.objectReferenceValue = descriptorParams;
+                descriptorParamsProp.objectReferenceValue = descriptorParams;
+            }
 
             // 変更を適用
             descriptorObj.ApplyModifiedProperties();
+        }
+
+        private static bool HasCombinedSupineMenu(ExpressionsMenu menu)
+        {
+            return menu != null && menu.controls != null && menu.controls.Any(IsCombinedSupineMenu);
+        }
+
+        private static bool HasOldSupineParameters(ExpressionParameters parameters)
+        {
+            return parameters != null && parameters.parameters != null && parameters.parameters.Any(IsSupineParameter);
         }
 
         private static List<ExpressionsMenuControl> RemoveCombinedExMenuControls(List<ExpressionsMenuControl> exMenuControls)

--- a/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
+++ b/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
@@ -122,6 +122,9 @@ namespace Supine
                 // 設置済みのMAPrefabを整理
                 SortAndCleanMAPrefab(maPrefabInstance, alreadyPlacedPrefab);
 
+                // SupineMASlot導入以前に設置された、マーカーの無いMA Prefabの残骸を削除（互換対応）
+                OldSupineCleaner.RemoveMarkerlessMAPrefabs(_avatar.transform, maPrefabInstance);
+
                 // 結合済みの古いごろ寝システムを削除
                 if (shouldCleanCombinedSupine) {
                     OldSupineCleaner.CleanCombinedSupine(_avatarDescriptor);

--- a/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
+++ b/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
@@ -23,8 +23,6 @@ namespace Supine
         public bool canCombine = true;
 
         private string MmmAssetPath           = "Assets/MinMinMart";
-        private string SupineNormalPrefabName = "SupineMA";
-        private string SupineExPrefabName     = "SupineMA_EX";
         private string _maPrefabGuid    = Utility.GuidList.prefabs.normal;
         private string _controllerGuid  = Utility.GuidList.controllers.normal;
         private string _appVersion      = Utility.GetAppVersion();
@@ -220,10 +218,10 @@ namespace Supine
 
         /// <summary>
         /// 新しいMA Prefabと古いMA Prefabの位置を整理する
-        /// EX⇔通常版の入れ替えも行う
+        /// 他バリアント（EX⇔通常版など）の入れ替えも行う
         /// </summary>
         /// <param name="newPrefab">新しいMA Prefab</param>
-        /// <param name="oldPrefab">古いMA Prefab</param>
+        /// <param name="oldPrefab">古いMA Prefab（同バリアントの既存設置分）</param>
         private void SortAndCleanMAPrefab(GameObject newPrefab, GameObject oldPrefab)
         {
             bool indexReplaced = false;
@@ -235,8 +233,8 @@ namespace Supine
                 indexReplaced = true;
             }
 
-            GameObject otherSupinePrefab = _exMode ? GameObject.Find(SupineNormalPrefabName) : GameObject.Find(SupineExPrefabName);
-            if (otherSupinePrefab)
+            GameObject otherSupinePrefab = FindOtherSupineSlot(newPrefab);
+            if (otherSupinePrefab != null)
             {
                 if (!indexReplaced)
                 {
@@ -246,6 +244,24 @@ namespace Supine
 
                 GameObject.DestroyImmediate(otherSupinePrefab);
             }
+        }
+
+        /// <summary>
+        /// アバター直下から、自分（newPrefab）以外の設置済みごろ寝システムMA Prefabを探す。
+        /// バリアント名を直接知らなくても、SupineMASlotの有無だけで判定する。
+        /// </summary>
+        /// <param name="newPrefab">今回設置したMA Prefab</param>
+        private GameObject FindOtherSupineSlot(GameObject newPrefab)
+        {
+            foreach (Transform child in _avatar.transform)
+            {
+                if (child.gameObject == newPrefab) continue;
+                if (child.GetComponent<SupineMASlot>() != null)
+                {
+                    return child.gameObject;
+                }
+            }
+            return null;
         }
 
         /// <summary>

--- a/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
+++ b/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
@@ -86,14 +86,12 @@ namespace Supine
         /// <param name="enableJumpAtDesktop">bool デスクトップでジャンプモーションを有効化</param>
         /// <param name="sittingPoseOrder1">int 座りポーズ1</param>
         /// <param name="sittingPoseOrder2">int 座りポーズ2</param>
-        /// <param name="shouldCleanCombinedSupine">bool 古いごろ寝システムを削除する</param>
         public void CreateMAPrefab(
             bool shouldInheritOriginalAnimation = true,
             bool disableJumpMotion = true,
             bool enableJumpAtDesktop = true,
             int sittingPoseOrder1 = 0,
-            int sittingPoseOrder2 = 1,
-            bool shouldCleanCombinedSupine = false
+            int sittingPoseOrder2 = 1
         )
         {
             if (canCombine)
@@ -126,9 +124,7 @@ namespace Supine
                 OldSupineCleaner.RemoveMarkerlessMAPrefabs(_avatar.transform, maPrefabInstance);
 
                 // 結合済みの古いごろ寝システムを削除
-                if (shouldCleanCombinedSupine) {
-                    OldSupineCleaner.CleanCombinedSupine(_avatarDescriptor);
-                }
+                OldSupineCleaner.CleanCombinedSupine(_avatarDescriptor);
 
                 Debug.Log("[VRCSupine] MA Prefab creation is done.");
             } else {

--- a/Packages/minminmean.supine/Editor/Supine/SupineCombinerEditor.cs
+++ b/Packages/minminmean.supine/Editor/Supine/SupineCombinerEditor.cs
@@ -16,7 +16,6 @@ namespace Supine
         private bool _shouldInheritOriginalAnimation = true;
         private bool _disableJumpMotion = true;
         private bool _enableJumpAtDesktop = true;
-        private bool _shouldCleanCombinedSupine = true;
 
         private int _sittingPose1 = 0;
         private int _sittingPose2 = 1;
@@ -81,11 +80,6 @@ namespace Supine
 
             EditorGUILayout.Space();
 
-            // 結合済みのごろ寝を削除するか
-            _shouldCleanCombinedSupine = EditorGUILayout.ToggleLeft(localizeDict.clean_combined_supine, _shouldCleanCombinedSupine);
-
-            EditorGUILayout.Space();
-
             // Checkボタン
             using (new GUILayout.VerticalScope())
             {
@@ -121,8 +115,7 @@ namespace Supine
                                 disableJumpMotion: _disableJumpMotion,
                                 enableJumpAtDesktop: _enableJumpAtDesktop,
                                 sittingPoseOrder1: _sittingPose1,
-                                sittingPoseOrder2: _sittingPose2,
-                                shouldCleanCombinedSupine: _shouldCleanCombinedSupine
+                                sittingPoseOrder2: _sittingPose2
                             );
                         }
                         catch (IOException e)

--- a/Packages/minminmean.supine/Editor/Supine/Utilities/LocalizeDictionary.cs
+++ b/Packages/minminmean.supine/Editor/Supine/Utilities/LocalizeDictionary.cs
@@ -32,7 +32,6 @@ namespace Supine
             public string ma_prefab_created_message;
             public string ma_prefab_create_failure;
             public string ma_prefab_create_failure_message;
-            public string clean_combined_supine;
         }
     }
 }

--- a/Packages/minminmean.supine/Runtime/Supine/Localize/en.json
+++ b/Packages/minminmean.supine/Runtime/Supine/Localize/en.json
@@ -23,6 +23,5 @@
     "ma_prefab_created": "Prefab creation successful",
     "ma_prefab_created_message": "Created the Modular Avatar Prefab.",
     "ma_prefab_create_failure": "Prefab creation failure",
-    "ma_prefab_create_failure_message": "Modular Avatar Prefab creation is failure.\nPlease check the console log.",
-    "clean_combined_supine": "Clean old Supine (Lower v3.x)"
+    "ma_prefab_create_failure_message": "Modular Avatar Prefab creation is failure.\nPlease check the console log."
 }

--- a/Packages/minminmean.supine/Runtime/Supine/Localize/ja.json
+++ b/Packages/minminmean.supine/Runtime/Supine/Localize/ja.json
@@ -23,6 +23,5 @@
     "ma_prefab_created": "Prefab生成成功",
     "ma_prefab_created_message": "Modular Avatar Prefabを生成しました。",
     "ma_prefab_create_failure": "Prefab生成失敗",
-    "ma_prefab_create_failure_message": "Modular Avatar Prefabの生成に失敗しました。\nコンソールログを確認してください。",
-    "clean_combined_supine": "古いごろ寝システム（v3.x以前）を削除する"
+    "ma_prefab_create_failure_message": "Modular Avatar Prefabの生成に失敗しました。\nコンソールログを確認してください。"
 }

--- a/Packages/minminmean.supine/Runtime/Supine/Prefab/SupineMA.prefab
+++ b/Packages/minminmean.supine/Runtime/Supine/Prefab/SupineMA.prefab
@@ -140,6 +140,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3509859782431372602}
   - component: {fileID: 5353848233879069659}
+  - component: {fileID: 1003122840647800}
   m_Layer: 0
   m_Name: SupineMA
   m_TagString: Untagged
@@ -182,10 +183,22 @@ MonoBehaviour:
   pathMode: 1
   matchAvatarWriteDefaults: 0
   relativePathRoot:
-    referencePath: 
+    referencePath:
     targetObject: {fileID: 0}
   layerPriority: 0
   mergeAnimatorMode: 1
+--- !u!114 &1003122840647800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2478647225827992499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 142708bfabbdb1c002954da4c073039b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &2703358847003626822
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/minminmean.supine/Runtime/Supine/SupineMASlot.cs
+++ b/Packages/minminmean.supine/Runtime/Supine/SupineMASlot.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace Supine
+{
+    /// <summary>
+    /// ごろ寝システムMA Prefabのルートにつけるマーカー。
+    /// 通常版/EX版どちらのバリアントかを問わず、
+    /// 「既に設置されている他のごろ寝システムMA Prefab」を名前を知らずに検出・整理するために使う。
+    /// </summary>
+    public class SupineMASlot : MonoBehaviour
+    {
+    }
+}

--- a/Packages/minminmean.supine/Runtime/Supine/SupineMASlot.cs.meta
+++ b/Packages/minminmean.supine/Runtime/Supine/SupineMASlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 142708bfabbdb1c002954da4c073039b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/minminmean.supine/Runtime/Supine/Version.txt
+++ b/Packages/minminmean.supine/Runtime/Supine/Version.txt
@@ -1,1 +1,1 @@
-Supine v4.3.2
+Supine v4.3.3

--- a/Packages/minminmean.supine/package.json
+++ b/Packages/minminmean.supine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minminmean.supine",
   "displayName": "Gorone System (Supine)",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Have a good sleep",
   "gitDependencies": {},
   "vpmDependencies": {


### PR DESCRIPTION
SupineCombiner previously had to know the EX package's prefab name ("SupineMA_EX") in order to remove it when switching back to the normal-only variant, creating a reverse dependency from the base package onto its extension. Add a SupineMASlot marker component to the MA prefab root and use it to find/replace any other installed Supine MA prefab, regardless of variant name.