### PR TITLE
Strip SupineMASlot via NDMF build plugin before upload

### DIFF
--- a/Packages/minminmean.supine/Editor/Supine/SupineMASlotCleanupPlugin.cs
+++ b/Packages/minminmean.supine/Editor/Supine/SupineMASlotCleanupPlugin.cs
@@ -1,0 +1,26 @@
+using nadena.dev.ndmf;
+using UnityEngine;
+
+[assembly: ExportsPlugin(typeof(Supine.SupineMASlotCleanupPlugin))]
+
+namespace Supine
+{
+    /// <summary>
+    /// SupineMASlotはエディタ上でごろ寝システムMA Prefabを識別するためだけのマーカーで、
+    /// アバターとしてアップロードする実体には不要（VRCSDKに未対応コンポーネントとして警告される）。
+    /// NDMFのビルド時に取り除く。
+    /// </summary>
+    public class SupineMASlotCleanupPlugin : Plugin<SupineMASlotCleanupPlugin>
+    {
+        protected override void Configure()
+        {
+            InPhase(BuildPhase.Optimizing).Run("Remove SupineMASlot markers", ctx =>
+            {
+                foreach (SupineMASlot slot in ctx.AvatarRootObject.GetComponentsInChildren<SupineMASlot>(true))
+                {
+                    Object.DestroyImmediate(slot);
+                }
+            });
+        }
+    }
+}

--- a/Packages/minminmean.supine/Editor/Supine/SupineMASlotCleanupPlugin.cs.meta
+++ b/Packages/minminmean.supine/Editor/Supine/SupineMASlotCleanupPlugin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46499d65ea4c31658a1576e93944a36f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/minminmean.supine/Editor/minminmean.supine.Editor.asmdef
+++ b/Packages/minminmean.supine/Editor/minminmean.supine.Editor.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "",
     "references": [
         "nadena.dev.modular-avatar.core",
+        "nadena.dev.ndmf",
         "VRC.SDK3A",
         "VRC.SDK3A.Editor",
         "VRC.SDKBase",

--- a/Packages/minminmean.supine/Runtime/Supine/Version.txt
+++ b/Packages/minminmean.supine/Runtime/Supine/Version.txt
@@ -1,1 +1,1 @@
-Supine v4.3.3
+Supine v4.3.4

--- a/Packages/minminmean.supine/package.json
+++ b/Packages/minminmean.supine/package.json
@@ -1,12 +1,13 @@
 {
   "name": "minminmean.supine",
   "displayName": "Gorone System (Supine)",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Have a good sleep",
   "gitDependencies": {},
   "vpmDependencies": {
     "com.vrchat.avatars": ">=3.7.0",
-    "nadena.dev.modular-avatar": ">=1.12.3"
+    "nadena.dev.modular-avatar": ">=1.12.3",
+    "nadena.dev.ndmf": ">=1.9.4"
   },
   "author": {
     "name": "MinMinMean",


### PR DESCRIPTION
SupineMASlot is only meaningful in the editor scene for identifying already-placed MA Prefabs; left on the avatar it trips VRCSDK's unrecognized-component upload warning since nothing else removes it. Add an NDMF Optimizing-phase plugin that destroys any SupineMASlot found on the built avatar, mirroring how Modular Avatar's own editor-only components never reach the uploaded avatar.