### PR TITLE
Implement IEditorOnly on SupineMASlot instead of an NDMF plugin

### DIFF
--- a/Packages/minminmean.supine/Runtime/Supine/SupineMASlot.cs
+++ b/Packages/minminmean.supine/Runtime/Supine/SupineMASlot.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using VRC.SDKBase;
 
 namespace Supine
 {
@@ -6,8 +7,9 @@ namespace Supine
     /// ごろ寝システムMA Prefabのルートにつけるマーカー。
     /// 通常版/EX版どちらのバリアントかを問わず、
     /// 「既に設置されている他のごろ寝システムMA Prefab」を名前を知らずに検出・整理するために使う。
+    /// IEditorOnlyを実装することで、VRCSDKの未対応コンポーネント警告やアバターへの実際の混入を防ぐ。
     /// </summary>
-    public class SupineMASlot : MonoBehaviour
+    public class SupineMASlot : MonoBehaviour, IEditorOnly
     {
     }
 }

--- a/Packages/minminmean.supine/Runtime/Supine/Version.txt
+++ b/Packages/minminmean.supine/Runtime/Supine/Version.txt
@@ -1,1 +1,1 @@
-Supine v4.3.3
+Supine v4.3.4

--- a/Packages/minminmean.supine/package.json
+++ b/Packages/minminmean.supine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minminmean.supine",
   "displayName": "Gorone System (Supine)",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Have a good sleep",
   "gitDependencies": {},
   "vpmDependencies": {


### PR DESCRIPTION
VRCSDK's own avatar-alert scan (AvatarValidation.FindIllegalComponents) excludes any component implementing VRC.SDKBase.IEditorOnly, which is the documented, public mechanism third-party tools (Avatar Optimizer, VRCFury, etc.) already rely on for exactly this purpose. Implementing it directly on SupineMASlot suppresses both the pre-build "Review Any Alerts" warning and the actual upload inclusion, without needing a custom NDMF build pass or any change to the prefab structure.