### PR TITLE
Improve the compatibility with AAO: Avatar Optimizer

### DIFF
--- a/Packages/minminmean.supine/Supine.asset
+++ b/Packages/minminmean.supine/Supine.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 672cf279ebc041f5b87addc7c6c980bb, type: 3}
+  m_Name: Supine
+  m_EditorClassIdentifier: 
+  comment: "\u3054\u308D\u5BDD\u30B7\u30B9\u30C6\u30E0\nhttps://booth.pm/ja/items/2886739\nhttps://minminmean.github.io/minminmart/"
+  meaninglessComponents:
+  - className: SupineMASlot
+    guid: 142708bfabbdb1c002954da4c073039b
+    fileID: 11500000
+  parametersReadByExternalTools: []
+  parametersChangedByExternalTools: []

--- a/Packages/minminmean.supine/Supine.asset.meta
+++ b/Packages/minminmean.supine/Supine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b60c2a4c108ecb4ba8f7d79dd840de8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
ごろ寝システム v4.3.3で導入されたSupineMASlotコンポーネントについて、AAO: Avatar Optimizerにて以下の画像のような警告が表示されてしまうため、Asset Descriptionファイルを追加することで警告が表示されないようにするPRです。
<img width="573" height="220" alt="image" src="https://github.com/user-attachments/assets/8b3bc603-fd8a-49e4-b52e-3c666b583f93" />


## 説明
NDMFプラグインはIEditorOnlyのコンポーネントが削除される(RemoveAvatarEditorOnly)よりも前に動作するため、AAOの処理時点ではSupineMASlotコンポーネントが残っており、警告が表示されてしまっています。
Asset Descriptionファイルを使用することで、アバタービルド時に当該コンポーネントを削除・無視しても問題ない旨をAAOに伝えることが出来ます。

詳細は https://vpm.anatawa12.com/avatar-optimizer/ja/docs/developers/make-your-components-compatible-with-aao/ および https://vpm.anatawa12.com/avatar-optimizer/ja/docs/developers/asset-description/ をご参照ください。