### PR TITLE
Fix ArgumentException caused by trailing newline in Version.txt

### DIFF
--- a/Packages/minminmean.supine/Editor/Supine/Utilities/Utility.cs
+++ b/Packages/minminmean.supine/Editor/Supine/Utilities/Utility.cs
@@ -105,7 +105,8 @@ namespace Supine
 
             private static string ReadTextFromGuid(string guid)
             {
-                return File.ReadAllText(AssetDatabase.GUIDToAssetPath(guid));
+                // 末尾の改行やBOMがパスに混入するとPath系APIが例外を投げるため必ず除去する
+                return File.ReadAllText(AssetDatabase.GUIDToAssetPath(guid)).Trim();
             }
         }
     }

--- a/Packages/minminmean.supine/Runtime/Supine/Version.txt
+++ b/Packages/minminmean.supine/Runtime/Supine/Version.txt
@@ -1,1 +1,1 @@
-Supine v4.3.5
+Supine v4.3.6

--- a/Packages/minminmean.supine/package.json
+++ b/Packages/minminmean.supine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minminmean.supine",
   "displayName": "Gorone System (Supine)",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "Have a good sleep",
   "gitDependencies": {},
   "vpmDependencies": {


### PR DESCRIPTION
Version.txt gained a trailing LF when it was edited through the GitHub web editor in 4.3.5. Utility.ReadTextFromGuid returned it verbatim, so _appVersion became "Supine v4.3.5\n" and MakeGeneratedDirPath embedded the newline in the generated asset path. Mono's Path.IsPathRooted treats control characters as invalid path characters, so CreateMAPrefab always failed with "ArgumentException: Illegal characters in path".

Remove the trailing newline and Trim() the text read from Version.txt so a stray newline or BOM can never reach a path again.