### PR TITLE
Sanitize the avatar name before using it in a generated asset path

### DIFF
--- a/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
+++ b/Packages/minminmean.supine/Editor/Supine/SupineCombiner.cs
@@ -42,7 +42,7 @@ namespace Supine
         public SupineCombiner(GameObject avatar, bool exMode = false)
         {
             _avatar = avatar;
-            _avatar_name_with_suffix = avatar.name;
+            _avatar_name_with_suffix = Utility.SanitizeFileName(avatar.name);
             _avatarDescriptor = avatar.GetComponent<VRCAvatarDescriptor>();
             _exMode = exMode;
             

--- a/Packages/minminmean.supine/Editor/Supine/Utilities/Utility.cs
+++ b/Packages/minminmean.supine/Editor/Supine/Utilities/Utility.cs
@@ -12,6 +12,7 @@ namespace Supine
         {
             private static string _appVersion;
             private static string _appVersionEX;
+            private const string FallbackFileName = "Avatar";
             private static GuidDictionary _guidList = JsonHelper.GetGuidList();
 
             public static GuidDictionary GuidList
@@ -49,6 +50,22 @@ namespace Supine
                 }
 
                 return path;
+            }
+
+            public static string SanitizeFileName(string name)
+            {
+                if (string.IsNullOrEmpty(name)) return FallbackFileName;
+
+                string sanitized = name;
+                foreach (char invalidChar in Path.GetInvalidFileNameChars())
+                {
+                    sanitized = sanitized.Replace(invalidChar, '_');
+                }
+
+                // Windowsは末尾の空白とドットを扱えない
+                sanitized = sanitized.Trim().TrimEnd('.').Trim();
+
+                return string.IsNullOrEmpty(sanitized) ? FallbackFileName : sanitized;
             }
 
             public static void CreateFolderRecursively(string path)


### PR DESCRIPTION
## 背景

`SupineCombiner` は `avatar.name` を無検査のまま生成パスに使っている。

```csharp
_avatar_name_with_suffix = avatar.name;
...
Assets/MinMinMart/<version>/Generated/<アバター名>/<アバター名>_<template>
```

このためアバター名にパスとして使えない文字が含まれていると、`Path.GetDirectoryName()` が
`ArgumentException: Illegal characters in path` を投げ、Prefab の生成が一切できなくなる。

Mono の `InvalidPathChars` は `"` `<` `>` `|` と制御文字 \x00–\x1F。加えてファイル名としては
`:` `*` `?` `/` `\` も使えず、Windows は末尾の空白・ドットを扱えない。

Version.txt の末尾改行による同種の不具合（#別PR）と原因は同じで、そちらを直してもアバター名側は残る。

## 修正

`Utility.SanitizeFileName()` を追加し、コンストラクタで通してから使う。

- `Path.GetInvalidFileNameChars()` に該当する文字をすべて `_` に置換
- 末尾の空白とドットを除去
- 空文字になる場合は `Avatar` にフォールバック

`_avatar_name_with_suffix` はパス組み立て以外には使われていないため、影響範囲は生成物のフォルダ名・ファイル名のみ。

## 影響範囲

これまで例外で生成できなかったアバター名でも通るようになる。既存ユーザーへの影響は、名前に不正文字を含むアバターのみ（そもそも生成できていなかったケース）。